### PR TITLE
Adding minimum TTL

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -33,6 +33,10 @@
 			'SRV',
 			'TXT',
 		];
+
+		// @var int minimum TTL
+		public const DNS_TTL_MIN = 120;
+
 		// @var array API credentials
 		private $key;
 

--- a/Module.php
+++ b/Module.php
@@ -35,7 +35,7 @@
 		];
 
 		// @var int minimum TTL
-		public const DNS_TTL_MIN = 120;
+		public const DNS_TTL_MIN = 30;
 
 		// @var array API credentials
 		private $key;


### PR DESCRIPTION
Prevents record creation failures such as:
```
Failed to create record `__acct_migration.domain.com' type TXT: Client error: `POST https://api.digitalocean.com/v2/domains/domain.com/records` resulted in a `422 Unprocessable Entity` response:
{"id":"unprocessable_entity","message":"record ttl must be greater than 30"}
```