### PR TITLE
Avoid duplicating apex NS records

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -36,6 +36,9 @@
 		// @var int minimum TTL
 		public const DNS_TTL_MIN = 30;
 
+		// Avoid duplicating apex NS records
+		public const SHOW_NS_APEX = false;
+
 		// @var array API credentials
 		private $key;
 


### PR DESCRIPTION
Normal behaviour will show apex NS and performing a zone reset will lead to new NS records to be created, both unexpected behaviour and actually unnecessary in the zone definition.

Going further and resetting multiple times the zone will lead to those NS records to be duplicated over and over.

Steps to replicate the issue:
1. Create an account with Digital Oceans as DNS provider
2. Reset the zone via panel
3. Cross-check between panel and DO Console

Result can be simply monitored through DO Console by searching in page for value `ns1.digitalocean.com`, which should have multiple entries after multiple resets.